### PR TITLE
Change WebSocket connection to kline stream

### DIFF
--- a/src/Binance_Websockets.cpp
+++ b/src/Binance_Websockets.cpp
@@ -78,7 +78,7 @@ void StartServer() {
  * This function creates the client WebSocket connection to Binance's WS Stream
  * API, and determines the behavior on message receipt.
  *
- * Currently, it conencts to Binance's Candlestick Data Stream for a 1 minute
+ * Currently, it connects to Binance's Candlestick Data Stream for a 1 minute
  * interval. It will cull extra information from the received JSON, and send
  * only what is currently necessary to the front.
  *


### PR DESCRIPTION
# Description
This PR changes the `Binance_Websockets.cpp` stream from the general WebSocket API to WebSocket Streams.

Rather than connecting to "wss://ws-api.binance.us:9443/ws-api/v3" and requesting the avgPrice with a JSON object, we are now connecting to the [Candlestick Data Stream](https://docs.binance.us/#trade-data-stream:~:text=time-,Candlestick%20Data%20Stream), which streams data down every 2000ms.

As such, there is no need to wait or deal with rate limits. Thus, closes #22.

This PR sets the stage for using candlestick charts in the front end.

## Images
<img width="383" height="731" alt="image" src="https://github.com/user-attachments/assets/f6c28452-ad8b-40bc-9489-c9a8540df378" />

<img width="834" height="652" alt="image" src="https://github.com/user-attachments/assets/f1ef5d54-c56f-4c0f-82b0-8e2a415072d2" />