### PR TITLE
Cleanup use effect

### DIFF
--- a/MarketUI/src/components/CandlestickChart.jsx
+++ b/MarketUI/src/components/CandlestickChart.jsx
@@ -10,6 +10,8 @@ const CandlestickChart = ({ coin, latestCandle, historicalCandles }) => {
   const chartContainerRef = useRef(null);
   const chartRef = useRef(null);
   const seriesRef = useRef(null);
+  const lastCoinRef = useRef(null);
+  const dataLoadedRef = useRef(false);
 
   // Create the chart once on mount
   useEffect(() => {
@@ -73,31 +75,55 @@ const CandlestickChart = ({ coin, latestCandle, historicalCandles }) => {
     };
   }, []);
 
-
-  useEffect(() => {
-    if (seriesRef.current) {
-      seriesRef.current.setData([]);
-    }
-  }, [coin]);
-
+  /* Updates the chart with the data for the currently selected coin.
+   * We update incrementally, unless the coin name changes or the histroical data
+   * has JUST arrived.
+   *
+   * 1. If we get an update that is *not* for the current coin, return.
+   * 2. Get a bool 'coinChanged' that tracks whether the coin changed or not.
+   * 2. If the coin changes...
+   *    2a. Set dataLoadedRef = false;
+   *    2b. Update the lastCoinRef's current to be this coin.
+   * 3. If the coin changed, or dataLoadedRef is false and we have historical data...
+   *    3a. Set the chart data from historicalCandles or an empty array if none.
+   *    3b. If we have historical data...
+   *        1. Adjust the chart timescale to fit.
+   *        2. Set dataLoadedRef = true;
+   *    3c. If coin changes or we have loaded data... return.
+   * 4. If we have a latestCandle and it has a valid time...
+   *    4a. Try-catch to update the chart.
+   *    4b. Print a warning w/ error message if it failed.
+  */
   useEffect(() => {
     if (!seriesRef.current) return;
 
-    seriesRef.current.setData(historicalCandles || []);
+    const coinChanged = lastCoinRef.current !== coin;
 
-    if (historicalCandles && historicalCandles.length > 0) {
-      chartRef.current?.timeScale().fitContent();
+    if (coinChanged) {
+      dataLoadedRef.current = false;
+      lastCoinRef.current = coin;
     }
-  }, [coin, historicalCandles]);
 
-  useEffect(() => {
-    if (!seriesRef.current || !latestCandle || !latestCandle.time) return;
-    try {
-      seriesRef.current.update(latestCandle);
-    } catch (err) {
-      console.warn('[CandlestickChart] Live update failed:', err.message);
+    // Check if the coin changed, or we're doing our first setData call.
+    if (coinChanged || (!dataLoadedRef.current && historicalCandles.length > 0)) {
+      seriesRef.current.setData(historicalCandles || []);
+
+      if (historicalCandles.length > 0) {
+        chartRef.current?.timeScale().fitContent();
+        dataLoadedRef.current = true;
+      }
+
+      if (coinChanged || dataLoadedRef.current) return;
     }
-  }, [latestCandle]);
+
+    if (latestCandle && latestCandle.time) {
+      try {
+        seriesRef.current.update(latestCandle);
+      } catch (err) {
+        console.warn('[Chart] Live update failed:', err.message);
+      }
+    }
+  }, [coin, latestCandle, historicalCandles]);
 
   return <div ref={chartContainerRef} className="ChartContainer" />;
 };

--- a/MarketUI/src/useCryptoSocket.jsx
+++ b/MarketUI/src/useCryptoSocket.jsx
@@ -28,9 +28,16 @@ const useCryptoSocket = (selectedCoin) => {
    * The websocket handlers use the activeCoinRef to determine the
    * currently selected coin.
    *
+   * Additionally updates setPrice based on the active coin.
+   *
    * 1. Set activeCoinRef.current to selectedCoin.
-   * 2. Set price as null.
-   * 3. Set latest candle as null.
+   * 2. Normalize selectedCoin to uppercase.
+   * 3. Get history from historicalData.
+   * 4. If we have historicalData...
+   *    4a. Set price as the last member of historicalData.
+   * 5. Else...
+   *    5a. Set price as null.
+   * 6. Set the latest candle as null.
    */
   useEffect(() => {
     activeCoinRef.current = selectedCoin;

--- a/MarketUI/src/useCryptoSocket.jsx
+++ b/MarketUI/src/useCryptoSocket.jsx
@@ -33,25 +33,36 @@ const useCryptoSocket = (selectedCoin) => {
    * 1. Set activeCoinRef.current to selectedCoin.
    * 2. Normalize selectedCoin to uppercase.
    * 3. Get history from historicalData.
-   * 4. If we have historicalData...
-   *    4a. Set price as the last member of historicalData.
-   * 5. Else...
-   *    5a. Set price as null.
-   * 6. Set the latest candle as null.
+   * 4. Get a map from allCoinsBuffer.
+   *    4a. Sort it.
+   *    4b. Get the last member.
+   * 5. If we have something in allCoinsBuffer...
+   *    5a. Use it: set price and candle.
+   * 6. Else if we have historicalData...
+   *    4a. Use it: set price and candle.
+   * 7. Else...
+   *    5a. Set price and candle as null.
    */
   useEffect(() => {
     activeCoinRef.current = selectedCoin;
 
     const coin = selectedCoin.toUpperCase();
     const history = historicalData[coin] || [];
+    const liveMap = allCoinsBuffer.current[coin];
 
-    if (history.length > 0) {
+    const liveArray = liveMap ? Array.from(liveMap.values()).sort((a, b) => a.time - b.time) : [];
+    const lastLive = liveArray.length > 0 ? liveArray[liveArray.length - 1] : null;
+
+    if (lastLive) {
+      setPrice(lastLive.close);
+      setLatestCandle(lastLive);
+    } else if (history.length > 0) {
       setPrice(history[history.length - 1].close);
+      setLatestCandle(null)
     } else {
       setPrice(null);
+      setLatestCandle(null);
     }
-
-    setLatestCandle(null);
   }, [selectedCoin, historicalData]);
 
   /* Receives live kline data from the backend, parses it, and updates

--- a/MarketUI/src/useCryptoSocket.jsx
+++ b/MarketUI/src/useCryptoSocket.jsx
@@ -34,9 +34,18 @@ const useCryptoSocket = (selectedCoin) => {
    */
   useEffect(() => {
     activeCoinRef.current = selectedCoin;
-    setPrice(null);
+
+    const coin = selectedCoin.toUpperCase();
+    const history = historicalData[coin] || [];
+
+    if (history.length > 0) {
+      setPrice(history[history.length - 1].close);
+    } else {
+      setPrice(null);
+    }
+
     setLatestCandle(null);
-  }, [selectedCoin]);
+  }, [selectedCoin, historicalData]);
 
   /* Receives live kline data from the backend, parses it, and updates
    * the relevant refs.

--- a/MarketUI/src/useCryptoSocket.jsx
+++ b/MarketUI/src/useCryptoSocket.jsx
@@ -1,186 +1,199 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 /* 
 Backend websocket connection.
 */
 const useCryptoSocket = (selectedCoin) => {
+
+  //---------------- USE STATEs ---------------------------------
   const [price, setPrice] = useState(null);
   const [latestCandle, setLatestCandle] = useState(null);
-
-  const SOCKET_URL = "ws://127.0.0.1:8080";
-  const DB_URL = "ws://127.0.0.1:8081";
-
-  const candleMapRef = useRef(new Map());
-  const lastCloseRef = useRef(null);
-  const prevCoinRef = useRef(null);
-
   const [holdings, setHoldings] = useState([]);
   const [transactions, setTransactions] = useState([]);
   const [historicalData, setHistoricalData] = useState({});
-  const dbSocketRef = useRef(null);
-  const [lastJsonMessage, setLastJsonMessage] = useState(null);
+  //-------------------------------------------------------------
 
-  const [combinedHistory, setCombinedHistory] = useState([]);
-  const historicalBuffer = useRef({});
+  //--------------- SOCKET URLS ---------------------------------
+  const SOCKET_URL = "ws://127.0.0.1:8080";
+  const DB_URL = "ws://127.0.0.1:8081";
+  //-------------------------------------------------------------
+
+  //------------------- REFS ------------------------------------
+  const activeCoinRef = useRef(selectedCoin);
+  const dbSocketRef = useRef(null);
   const allCoinsBuffer = useRef({});
-  /* useEffect() for WebSocket socket.
+  const historicalBuffer = useRef({});
+  //-------------------------------------------------------------
+
+  /* Keeps activeCoinRef in sync with the currently selected coin.
+   * The websocket handlers use the activeCoinRef to determine the
+   * currently selected coin.
    *
-   * 1. Define WebSocket socket with SOCKET_URL.
-   * 2. Set bool isStartup = true.
-   * 2. Define the socket's onmessage behavior.
-   *    2a. Parse the received JSON into jsonReceived
-   *    2b. Check if isStartup.
-   *        - setHoldings with received data.
-   *        - Set isStartup = false if last = true.
-   *    2c. If it's a kline...
-   *        - setLastJsonMessage with the received JSON.
-   * 3. Close the socket when finished.
+   * 1. Set activeCoinRef.current to selectedCoin.
+   * 2. Set price as null.
+   * 3. Set latest candle as null.
+   */
+  useEffect(() => {
+    activeCoinRef.current = selectedCoin;
+    setPrice(null);
+    setLatestCandle(null);
+  }, [selectedCoin]);
+
+  /* Receives live kline data from the backend, parses it, and updates
+   * the relevant refs.
    *
-   * '[]' set to run this useEffect only once on startup.
-   *
-   * More information on this WebSocket API can be found at:
-   * https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API
-  */
+   * 1. Declare a new socket.
+   * 2. Determine onmessage behavior as follows:
+   *    2a. Parse the event data into a JSON.
+   *    2b. If that JSON does not have 'Kline', then return.
+   *    2c. If the allCoinsBuffer does not have the current coin...
+   *        a. Create a new map for that coin in allCoinsBuffer.
+   *    2d. Get the Map for that coin, and check if a timestamp exists for it.
+   *    2e. Create a new candle from the parsed JSON.
+   *    2f. Set that candle onto the map.
+   *    2g. If that coin is the currently selected coin...
+   *        a. Set price and set latest candle.
+   * 3. Cleanup : close socket.
+   */
   useEffect(() => {
     const socket = new WebSocket(SOCKET_URL);
 
     socket.onmessage = (event) => {
-      const jsonReceived = JSON.parse(event.data);
-      setLastJsonMessage(jsonReceived);
-    }
+      const data = JSON.parse(event.data);
+      if (!data.Kline) return;
+
+      const coin = data.Coin.toUpperCase();
+      const k = data.Kline;
+      const timeSeconds = Math.floor(k.StartTime / 1000);
+
+      if (!allCoinsBuffer.current[coin]) {
+        allCoinsBuffer.current[coin] = new Map();
+      }
+
+      const coinMap = allCoinsBuffer.current[coin];
+      const existing = coinMap.get(timeSeconds);
+
+      const candle = {
+        time: timeSeconds,
+        open: existing ? existing.open : parseFloat(k.Open),
+        high: Math.max(parseFloat(k.High), existing ? existing.high : 0),
+        low: Math.min(parseFloat(k.Low), existing ? existing.low : Infinity),
+        close: parseFloat(k.Close),
+      };
+
+      coinMap.set(timeSeconds, candle);
+
+      if (coin === activeCoinRef.current.toUpperCase()) {
+        setPrice(candle.close);
+        setLatestCandle(candle);
+      }
+    };
+
     return () => socket.close();
   }, []);
 
+  /* Receives historical data from the backend, parses it, and updates
+   * historicalBuffer.
+   *
+   * 1. Declare a new socket.
+   * 2. Determine onmessage behavior as follows:
+   *    2a. Parse the event data into a JSON.
+   *    2b. Open a switch case on data.dataType:
+   *        a. If "holding" ... set holdings.
+   *        b. If "transaction" ... set transaction.
+   *        c. If "historical" ...
+   *           1. If the historicalBuffer does not have the current coin...
+   *              a. Make an empty array for that coin.
+   *           2. Create and push a new candle to historicalBuffer.
+   *           3. If it's the last piece of historical data...
+   *              a. Set historicalData from historicalBuffer.
+   * 3. Cleanup : close socket.
+   */
   useEffect(() => {
     const socket = new WebSocket(DB_URL);
     dbSocketRef.current = socket;
+
     socket.onmessage = (event) => {
       const data = JSON.parse(event.data);
 
-      if (data.dataType === "holding") {
-        setHoldings((prev) => [...prev, data]);
-        return;
-      }
+      switch (data.dataType) {
+        case "holding":
+          setHoldings((prev) => [...prev, data]);
+          break;
+        case "transaction":
+          setTransactions((prev) => [...prev, data]);
+          break;
+        case "historical":
+          const coin = data.coin.toUpperCase();
+          if (!historicalBuffer.current[coin]) historicalBuffer.current[coin] = [];
 
-      if (data.dataType === "transaction") {
-        setTransactions((prev) => [...prev, data]);
-        return;
-      }
+          historicalBuffer.current[coin].push({
+            time: data.time,
+            open: data.price,
+            high: data.price,
+            low: data.price,
+            close: data.price
+          });
 
-      if (data.dataType === "historical") {
-        const coinupper = data.coin.toUpperCase();
-
-        if (!historicalBuffer.current[coinupper]) historicalBuffer.current[coinupper] = [];
-
-        historicalBuffer.current[coinupper].push({
-          time: data.time,
-          open: data.price,
-          high: data.price,
-          low: data.price,
-          close: data.price
-        });
-
-        if (data.last) {
-          setHistoricalData((prev) => ({
-            ...prev,
-            [coinupper]: [...historicalBuffer.current[coinupper]]
-          }));
-        }
-        return;
+          if (data.last) {
+            setHistoricalData(prev => ({
+              ...prev, [coin]: [...historicalBuffer.current[coin]]
+            }));
+          }
+          break;
       }
     };
     return () => socket.close();
   }, []);
 
-
-
-  useEffect(() => {
-    if (prevCoinRef.current !== selectedCoin) {
-      candleMapRef.current = new Map();
-      lastCloseRef.current = null;
-      setLatestCandle(null);
-      setPrice(null);
-      prevCoinRef.current = selectedCoin;
-    }
-  }, [selectedCoin])
-
-  useEffect(() => {
-    if (!lastJsonMessage || !lastJsonMessage.Kline) { return; }
-
-    const coin = lastJsonMessage.Coin.toUpperCase();
+  /* const combinedHistory.
+   *
+   * Uses useMemo to combine any and all received live klines with historical data,
+   * such that all charts have updated data, even when they are not selected, and
+   * each chart is able to load all data it needs from one location.
+   *
+   * 1. Normalize the selectedCoin to uppercase.
+   * 2. Get the histroical data for the active coin or a blank array if none.
+   * 3. Get the current coin's data from the allCoinsBuffer.
+   * 4. Convert Map valus into an Array, then sort.
+   * 5. Return the spread of the historical data and liveData.
+   * 6. Wrap all of that into a useMemo and store the result in combinedHistory.
+   */
+  const combinedHistory = useMemo(() => {
     const activeCoin = selectedCoin.toUpperCase();
-    const k = lastJsonMessage.Kline;
-    const timeSeconds = Math.floor(k.StartTime / 1000);
+    const csvData = historicalData[activeCoin] || [];
+    const liveBuffer = allCoinsBuffer.current[activeCoin];
 
-    if (!allCoinsBuffer.current[coin]) {
-      allCoinsBuffer.current[coin] = new Map();
-    }
+    const liveData = liveBuffer ? Array.from(liveBuffer.values()).sort((a, b) => a.time - b.time) : [];
 
-    const coinMap = allCoinsBuffer.current[coin];
-    const existing = coinMap.get(timeSeconds);
+    return [...csvData, ...liveData];
+  }, [selectedCoin, historicalData, latestCandle]);
 
-    const candle = {
-      time: timeSeconds,
-      open: existing ? existing.open : parseFloat(k.Open),
-      high: Math.max(parseFloat(k.High), existing ? existing.high : 0),
-      low: Math.min(parseFloat(k.Low), existing ? existing.low : Infinity),
-      close: parseFloat(k.Close),
-    };
-
-    coinMap.set(timeSeconds, candle);
-
-    if (coin === activeCoin) {
-      setPrice(candle.close);
-      setLatestCandle({ ...candle });
-    }
-
-  }, [lastJsonMessage, selectedCoin]);
-
+  /* const trade.
+   *
+   * Enables sending trades over the DataBase websocket.
+   *
+   * 1. If the websocket is open and price is not null...
+   *    1a. Log to console the trade we send.
+   *    1b. Send the trade.
+   *    1c. If buy...
+   *        a. setHoldings with the traded coin.
+   *    1d. If sell...
+   *        a. Remove the last traded coin from setHoldings via slice.
+   */
   const trade = (type, quantity) => {
-    if (dbSocketRef.current?.readyState === WebSocket.OPEN) {
-      if (price === null) {
-        console.warn("No price yet, trade blocked.");
-        return;
-      }
-      if (!quantity || quantity <= 0) {
-        console.warn("Invalid quantity, trade blocked.");
-        return;
-      }
-      const tradeData = {
-        type: type,
-        coin: selectedCoin,
-        price: price,
-        quantity: quantity
-      };
+    if (dbSocketRef.current?.readyState === WebSocket.OPEN && price !== null) {
+      const tradeData = { type, coin: selectedCoin, price, quantity };
+      console.log("Sent trade: ", tradeData);
+      dbSocketRef.current.send(JSON.stringify(tradeData));
+
 
       if (type === 'buy') {
         setHoldings((prev) => [...prev, tradeData]);
       } else if (type === 'sell') {
         setHoldings(prevHoldings => prevHoldings.slice(0, -1));
       }
-      console.log("Sending to backend:", tradeData);
-      dbSocketRef.current.send(JSON.stringify(tradeData));
     }
   };
-
-  useEffect(() => {
-    const activeCoin = selectedCoin.toUpperCase();
-    const csvData = historicalData[activeCoin] || [];
-    const liveBuffer = allCoinsBuffer.current[activeCoin];
-
-    const liveData = liveBuffer
-      ? Array.from(liveBuffer.values()).sort((a, b) => a.time - b.time) : [];
-
-    const combined = [...csvData, ...liveData];
-    setCombinedHistory(combined);
-
-    if (combined.length > 0) {
-      const lastPrice = combined[combined.length - 1].close;
-      setPrice(prev => (typeof prev === 'number' ? prev : lastPrice));
-    } else {
-      setPrice("Loading...");
-    }
-  }, [selectedCoin, historicalData]);
-
   return { price, latestCandle, holdings, transactions, historicalCandles: combinedHistory, trade };
 };
 export default useCryptoSocket;


### PR DESCRIPTION
# Description

Here, I tackle the multiple conflicting `UseEffect()` calls. Instead of having multiple `UseEffect()` that listen for changes on the same data stream or a derivative of it, we simplify the files into as _few_ `UseEffect()` calls as is reasonable, each with a documented separation of concerns.

Broken out into `const`s when possible. In this case, only `const combinedHistory = useMemo(() => {...};` was a candidate for that.

App *seems* to load much faster, though that's subjective, and we don't measure it or have an objective measure to compare to.

All charts load all historical data. No more 'sticky charts'.