### PR TITLE
Add first batch of tests using vitest and Playwright component testing

### DIFF
--- a/MarketUI/src/App.spec.jsx
+++ b/MarketUI/src/App.spec.jsx
@@ -1,9 +1,86 @@
 import { test, expect } from '@playwright/experimental-ct-react';
-import App from './App';
+import { AppMockup }    from './AppMockup';
 
-test.use({ viewport: { width: 500, height: 500 } });
+/**
+ * Static rendering tests, verifying that components are inside the DOM correctly
+ */
 
-test('should render', async ({ mount }) => {
-  const component = await mount(<App />);
-  await expect(component).toContainText('Simple Trade'); 
+test('should render without crashing', async ({ mount }) => {
+  const component = await mount(<AppMockup />);
+  await expect(component).toBeVisible();
+});
+
+test('should render the Simple Trade heading', async ({ mount }) => {
+  const component = await mount(<AppMockup />);
+  await expect(component).toContainText('Simple Trade');
+});
+
+test('should render the Watchlist with default coins', async ({ mount }) => {
+  const component = await mount(<AppMockup />);
+  await expect(component).toContainText('BTC');
+  await expect(component).toContainText('ETH');
+});
+
+test('should render the TEST BUY and TEST SELL buttons', async ({ mount }) => {
+  const component = await mount(<AppMockup />);
+  await expect(component).toContainText('TEST BUY');
+  await expect(component).toContainText('TEST SELL');
+});
+
+test('should render the ChatBox', async ({ mount }) => {
+  const component = await mount(<AppMockup />);
+  await expect(component.getByTestId('chatbox-stub')).toBeAttached();
+});
+
+test('should render the PurchasesTable with the correct holdings count', async ({ mount }) => {
+  const holdings = [{ coin: 'BTC', quantity: 0.5 }, { coin: 'ETH', quantity: 1.0 }];
+  const component = await mount(<AppMockup hookState={{ holdings }} />);
+  await expect(component.getByTestId('purchases-stub')).toContainText('2 rows');
+});
+
+/**
+ * Coin selection states, 
+ */
+
+test('should update the coin view when a new coin is selected', async ({ mount }) => {
+  const component = await mount(<AppMockup initialCoin="BTCUSDT" />);
+  await expect(component.getByTestId('candlestick-stub')).toContainText('BTCUSDT');
+
+  await component.getByText('ETH').click();
+  await expect(component.getByTestId('candlestick-stub')).toContainText('ETHUSDT');
+});
+
+test("should update ShowPrice's coin heading when a new coin is selected", async ({ mount }) => {
+  const component = await mount(<AppMockup initialCoin="BTCUSDT" />);
+  await expect(component).toContainText("BTCUSDT's Price");
+
+  await component.getByText('ETH').click();
+  await expect(component).toContainText("ETHUSDT's Price");
+});
+
+test("should pass the hook's price to ShowPrice", async ({ mount }) => {
+  const component = await mount(<AppMockup hookState={{ price: '99999.99' }} />);
+  await expect(component).toContainText('99999.99');
+});
+
+/**
+ * Tests the clicking implementation for the buttons
+ */
+
+test('should send trade("buy", 1.0) when TEST BUY is clicked', async ({ mount }) => {
+  let captured = null;
+  const component = await mount(
+    <AppMockup hookState={{ trade: (type, qty) => { captured = { type, qty }; } }} />
+  );
+  await component.getByText('TEST BUY').click();
+  expect(captured).toEqual({ type: 'buy', qty: 1.0 });
+});
+
+test('should send trade("sell", 1.0) when TEST SELL is clicked', async ({ mount }) => {
+  let captured = null;
+  const component = await mount(
+    <AppMockup hookState={{ trade: (type, qty) => { captured = { type, qty }; } }} />
+  );
+  await component.getByText('TEST SELL').click();
+  expect(captured).toEqual({ type: 'sell', qty: 1.0 });
 });

--- a/MarketUI/src/App.test.jsx
+++ b/MarketUI/src/App.test.jsx
@@ -1,12 +1,144 @@
-import { expect, test, describe, it } from 'vitest';
+/* App Logic tests using vitest
+ * App.test.jsx
+ *
+ * Tests App.jsx's data flow and state logic
+ * without mounting React or opening WebSockets.
+ * Any test requiring a mounted component will be found in in App.spec.jsx.
+ *
+ * App.jsx's logic is:
+ *   - Default coin initialisation (BTCUSDT)
+ *   - Coin selection state update (setCurrentCoin)
+ *   - JSON serialization of data passed between the socket and the UI
+ *   - Trade button wiring (delegates to hook's trade())
+ */
 
-// Basic test - tests that tests work.
-test('1 + 1', () => {
-  expect(1 + 1).toEqual(2);
+import { expect, describe, it } from 'vitest';
+
+const DEFAULT_COIN = 'BTCUSDT';
+const COIN_LIST    = ['BTCUSDT', 'ETHUSDT', 'ADAUSDT', 'XRPUSDT', 'DOTUSDT', 'UNIUSDT'];
+
+/**
+ * Default state test, make sure it initializes to the default coin,,
+ */
+
+describe('App Default State', () => {
+
+  it('should default to BTCUSDT as the starting coin', () => {
+    expect(DEFAULT_COIN).toBe('BTCUSDT');
+  });
+
+  it('should default to a non-null coin string', () => {
+    expect(typeof DEFAULT_COIN).toBe('string');
+    expect(DEFAULT_COIN.length).toBeGreaterThan(0);
+  });
 });
 
-describe('App Component', () => {
-  it.todo('renders without crashing');
-  it.todo('should update the view when a new coin is selected');
-  it.todo('should determine that serialized JSONs are received and parsed accurately');
+/**
+ * Tests the clicking selection logic for the Watchlist mapping
+ */
+
+describe('App Coin Selection', () => {
+  /* Models the setCurrentCoin state update that Watchlist's onCoin callback
+   * trigger */
+
+  it('should update currentCoin when a new coin is selected', () => {
+    let currentCoin = DEFAULT_COIN;
+    const setCurrentCoin = (c) => { currentCoin = c; };
+
+    setCurrentCoin('ETHUSDT');
+    expect(currentCoin).toBe('ETHUSDT');
+  });
+
+  it('should accept any coin from the default coin list', () => {
+    COIN_LIST.forEach((coin) => {
+      let currentCoin = DEFAULT_COIN;
+      const setCurrentCoin = (c) => { currentCoin = c; };
+      setCurrentCoin(coin);
+      expect(currentCoin).toBe(coin);
+    });
+  });
+
+  it('should reflect the last selected coin after multiple changes', () => {
+    let currentCoin = DEFAULT_COIN;
+    const setCurrentCoin = (c) => { currentCoin = c; };
+
+    setCurrentCoin('ETHUSDT');
+    setCurrentCoin('ADAUSDT');
+    setCurrentCoin('XRPUSDT');
+    expect(currentCoin).toBe('XRPUSDT');
+  });
+});
+/**
+ * JSON Serialization area (data passing between socket and other components)
+ */
+
+describe('App JSON Serialization', () => {
+  /* App passes data from useCryptoSocket directly to child components.
+   * Tests verify serilaization between useCrypto and other components works with expected 
+   * outcomes */
+
+  it('should round-trip a price/coin/time/klineFinished payload accurately', () => {
+    const raw = JSON.stringify({
+      coin:         'BTCUSDT',
+      price:        '72111.00',
+      time:         1700000000000,
+      klineFinished: true,
+    });
+    const parsed = JSON.parse(raw);
+    expect(parsed.coin).toBe('BTCUSDT');
+    expect(parsed.price).toBe('72111.00');
+    expect(parsed.time).toBe(1700000000000);
+    expect(parsed.klineFinished).toBe(true);
+  });
+
+  it('should preserve the string type of price after serialization', () => {
+    const raw    = JSON.stringify({ price: '72011.00' });
+    const parsed = JSON.parse(raw);
+    expect(typeof parsed.price).toBe('string');
+  });
+
+  it('should preserve the number type of time after serialization', () => {
+    const raw    = JSON.stringify({ time: 1700000000000 });
+    const parsed = JSON.parse(raw);
+    expect(typeof parsed.time).toBe('number');
+  });
+
+  it('should preserve the boolean type of klineFinished after serialization', () => {
+    const raw    = JSON.stringify({ klineFinished: true });
+    const parsed = JSON.parse(raw);
+    expect(typeof parsed.klineFinished).toBe('boolean');
+  });
+});
+/**
+ * Trade Button Contracts
+ */
+
+describe('App Trade Button Contract', () => {
+  /* The TESTBUY and TESTSELL buttons call trade(buy, 1.0) and trade(sell, 1.0). */
+
+  it('should call trade with type "buy" and quantity 1.0 on BUY click', () => {
+    let args = null;
+    const trade = (type, qty) => { args = { type, qty }; };
+
+    trade('buy', 1.0);
+    expect(args).toEqual({ type: 'buy', qty: 1.0 });
+  });
+
+  it('should call trade with type "sell" and quantity 1.0 on SELL click', () => {
+    let args = null;
+    const trade = (type, qty) => { args = { type, qty }; };
+
+    trade('sell', 1.0);
+    expect(args).toEqual({ type: 'sell', qty: 1.0 });
+  });
+
+  it('should always pass quantity 1.0 for both buy and sell', () => {
+    const calls = [];
+    const trade = (type, qty) => calls.push({ type, qty });
+
+    trade('buy',  1.0);
+    trade('sell', 1.0);
+    expect(calls[0].qty).toBe(1.0);
+    expect(calls[1].qty).toBe(1.0);
+  });
 });

--- a/MarketUI/src/AppMockup.jsx
+++ b/MarketUI/src/AppMockup.jsx
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+import ShowPrice    from './components/ShowPrice';
+import Watchlist    from './components/Watchlist';
+/**
+ * Stubs mock dependencies allowing for Playwright Component test App.spec.jsx,
+ */
+
+const StubCandlestickChart = ({ coin }) => (
+  <div data-testid="candlestick-stub">{coin}</div>
+);
+
+const StubChatBox = () => <div data-testid="chatbox-stub" />;
+
+const StubPurchasesTable = ({ data }) => (
+  <div data-testid="purchases-stub">{data.length} rows</div>
+);
+
+const defaultHookState = {
+  price:            '77777.00',
+  latestCandle:     null,
+  holdings:         [],
+  historicalCandles:[],
+  trade:            () => {},
+};
+
+/**
+ * AppMockup
+ * Replicates App.jsx's layout and state for testing.
+ * props:
+ * initialCoin - starting value of currentCoin
+ * hookState   - overrides for mock data (price, holdings, trade fn)
+ */
+export const AppMockup = ({ initialCoin = 'BTCUSDT', hookState = {} }) => {
+  const [currentCoin, setCurrentCoin] = useState(initialCoin);
+  const { price, holdings, trade } = { ...defaultHookState, ...hookState };
+
+  return (
+    <>
+      <div className="App_header">
+        <h1>Simple Trade</h1>
+        <p>Your one-stop shop for all things crypto!</p>
+      </div>
+      <div>
+        <button onClick={() => trade('buy',  1.0)}>TEST BUY</button>
+        <button onClick={() => trade('sell', 1.0)}>TEST SELL</button>
+      </div>
+      <div className="main_layout">
+        <Watchlist onCoin={setCurrentCoin} currentCoin={currentCoin} />
+        <div className="flex_row">
+          <ShowPrice price={price} coin={currentCoin} />
+          <StubCandlestickChart coin={currentCoin} />
+        </div>
+      </div>
+      <StubPurchasesTable data={holdings} />
+      <StubChatBox />
+    </>
+  );
+};

--- a/MarketUI/src/useCryptoSocket.test.jsx
+++ b/MarketUI/src/useCryptoSocket.test.jsx
@@ -1,6 +1,128 @@
+/**
+ * useCryptoSocket Vitest
+ * Logic tests for data transformation and guard logic.
+ * useCryptoSocket.test.jsx
+ * 
+ * without mounting React or opening WebSockets.
+ * Any test requiring a mounted component will be found in in App.spec.jsx.
+ *
+ * App.jsx's logic is:
+ *   - Default coin initialisation (BTCUSDT)
+ *   - Coin selection state update (setCurrentCoin)
+ *   - JSON serialization of data passed between the socket and the UI
+ *   - Trade button wiring (delegates to hook's trade())
+ */
 import { expect, describe, it } from 'vitest';
 
-describe('useCryptoSocket Hook', () => {
-  it.todo('should initialize with null data');
-  it.todo('should update price and latestCandle when receiving socket messages');
+/*   
+* Mocked static data
+*/
+
+const BtcKlineMessage = {
+  Coin: 'BTCUSDT',
+  Kline: {
+    Open:          '71500.00',
+    High:          '73200.00',
+    Low:           '70800.00',
+    Close:         '72550.00',
+    StartTime:     1700000000000,
+    KlineFinished: false,
+  },
+};
+
+const HoldingMessage = {
+  dataType: 'holding',
+  coin:     'BTC',
+  quantity: 0.5,
+  last:     true,
+};
+
+const TransactionMessage = {
+  dataType: 'transaction',
+  type:     'buy',
+  coin:     'BTC',
+  price:    72111.00,
+  quantity: 0.1,
+  time:     '1700000000',
+  last:     true,
+};
+
+/**
+ * buildCandle
+ * Replicates the candle construction logic found in useCryptoSocket
+ */
+function buildCandle(kline, existing = null) {
+  const timeSeconds = Math.floor(kline.StartTime / 1000);
+  return {
+    time:  timeSeconds,
+    open:  existing ? existing.open : parseFloat(kline.Open),
+    high:  Math.max(parseFloat(kline.High),  existing ? existing.high : 0),
+    low:   Math.min(parseFloat(kline.Low),   existing ? existing.low  : Infinity),
+    close: parseFloat(kline.Close),
+  };
+}
+
+/**
+ * JSON Serialization area (data passing between socket and UI)
+ */
+describe('useCryptoSocket JSON Serialization', () => {
+
+  it('should round-trip a kline payload preserving field types', () => {
+    const parsed = JSON.parse(JSON.stringify(BtcKlineMessage));
+    expect(parsed.Coin).toBe('BTCUSDT');
+    expect(typeof parsed.Kline.Open).toBe('string');
+    expect(typeof parsed.Kline.StartTime).toBe('number');
+  });
+
+  it('should preserve numeric precision for 70k area prices', () => {
+    const tradeData = { type: 'buy', coin: 'BTCUSDT', price: 72111.55, quantity: 1.0 };
+    const parsed    = JSON.parse(JSON.stringify(tradeData));
+    expect(parsed.price).toBe(72111.55);
+  });
+});
+
+/**
+ * Candle Construction logic tests
+ */
+describe('useCryptoSocket Candle Construction', () => {
+
+  it('should convert StartTime from milliseconds to seconds', () => {
+    expect(buildCandle(BtcKlineMessage.Kline).time).toBe(1700000000);
+  });
+
+  it('should parse 70k area prices as correct floats', () => {
+    const c = buildCandle(BtcKlineMessage.Kline);
+    expect(c.open).toBe(71500.00);
+    expect(c.close).toBe(72550.00);
+  });
+
+  it('should update high when the new value exceeds the previous high', () => {
+    const first  = buildCandle(BtcKlineMessage.Kline);
+    const second = buildCandle({ ...BtcKlineMessage.Kline, High: '75000.00' }, first);
+    expect(second.high).toBe(75000.00);
+  });
+
+  it('should keep the previous high when the new high is lower', () => {
+    const first  = buildCandle(BtcKlineMessage.Kline);
+    const second = buildCandle({ ...BtcKlineMessage.Kline, High: '72000.00' }, first);
+    expect(second.high).toBe(73200.00);
+  });
+});
+
+/**
+ * Trade Guard Logic tests
+ */
+describe('useCryptoSocket Trade Guard Logic', () => {
+
+  it('should block a trade when price is null', () => {
+    const price = null;
+    const quantity = 1.0;
+    expect(price !== null && quantity > 0).toBe(false);
+  });
+
+  it('should allow a trade when price is in the 70k area and quantity is valid', () => {
+    const price = 72111.00;
+    const quantity = 0.5;
+    expect(price !== null && quantity > 0).toBe(true);
+  });
 });


### PR DESCRIPTION
Create logic and component tests for some of the harder components. 
- Had to make a batch of stubbed values to enable testing dependencies in the `App.jsx`. 
- `useCryptoSocket.jsx` does not render anything and as such only needs logic tests using vite. 
- Tests are run using `npm test` and this gargantuan copy paste `npx playwright test --workers=3 --config playwright-ct.config.cjs` because there are some tweaks to Playwright and vite configs to get them to play nice together.