### PR TITLE
More DBH Tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,22 +59,26 @@ include(GoogleTest)
 FetchContent_Declare(                       # Define the content to be fetched, and from where.
   ixwebsocket                               # Content's name.
   GIT_REPOSITORY https://github.com/machinezone/IXWebSocket.git
+  FIND_PACKAGE_ARGS NAMES ixwebsocket IXWebSocket
 )
 
 FetchContent_Declare(
   json
   GIT_REPOSITORY https://github.com/nlohmann/json.git
+  FIND_PACKAGE_ARGS NAMES nlohmann_json nlohmann::json nlohmann_json::nlohmann_json
 )
 
 FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
   GIT_TAG v1.17.0
+  FIND_PACKAGE_ARGS NAMES gtest GoogleTest gmock GMock
 )
 
 FetchContent_Declare(
   webview
   GIT_REPOSITORY https://github.com/webview/webview.git
+  FIND_PACKAGE_ARGS NAMES webview WebView
 )
 
 FetchContent_Declare(

--- a/test/DatabaseHandlerTest.cpp
+++ b/test/DatabaseHandlerTest.cpp
@@ -409,6 +409,7 @@ TEST_F(Database_HandlerTest, Transactions_Are_Sent) {
  * 11. Stop client, clean up pointers.
  */
 TEST_F(Database_HandlerTest, Ten_Transactions_Are_Sent) {
+  filesystem::remove_all("./testData/transactionHistory.csv");
   Database_Handler *Database = new Database_Handler("./testData/");
   mutex PushLocker;
   json Transaction;
@@ -501,6 +502,7 @@ TEST_F(Database_HandlerTest, Ten_Transactions_Are_Sent) {
 
   client.stop();
   delete Database;
+  filesystem::remove_all("./testData/transactionHistory.csv");
 }
 
 /* Sends_Historical_Data

--- a/test/DatabaseHandlerTest.cpp
+++ b/test/DatabaseHandlerTest.cpp
@@ -274,6 +274,7 @@ TEST_F(TestDB, Record_10_Transactions) {
 TEST_F(Database_HandlerTest, Holdings_Are_Sent) {
   ofstream Holding("./testData/holdings.csv");
   Holding << "BTCUSDT,1.5" << endl;
+  Holding.close();
 
   promise<json> ReceivedHolding;
   future<json> FutureReceivedHolding = ReceivedHolding.get_future();
@@ -306,4 +307,190 @@ TEST_F(Database_HandlerTest, Holdings_Are_Sent) {
   EXPECT_EQ(result["last"], true);
 
   client.stop();
+}
+
+/* Transactions_Are_Sent
+ *
+ * This test uses the Database_HandlerTest fixture.
+ * Here, we claim that when given a valid transaction to send, and a webSocket
+ * client connecting to a server calling the sendTransactionHistory() method, we
+ * receive a transaction from transactionHistory.csv
+ *
+ * 1. Put a "basic" transaction into "./testData/transactionHistory.csv"
+ * 2. Get a promise / future JSON.
+ * 3. Make a webSocket client.
+ *    3a. Set its url.
+ * 4. Set the client's callback behavior.
+ *    4a. If we received a message, parse it into a JSON.
+ *    4b. If that message is a transaction, set our promise to the received
+ *        JSON.
+ * 5. Start the client.
+ * 6. Assert the future is ready, and wait up to one second for it.
+ * 7. Get the result from the future.
+ * 8. Expect that each member of our result matches what should have been sent.
+ *    8a. The data from data from our "basic" transaction.
+ *    8b. The dataType of "transaction"
+ *    8c. The last transaction flag is set, since we only inserted one
+ *        transaction.
+ * 9. Stop the client.
+ */
+TEST_F(Database_HandlerTest, Transactions_Are_Sent) {
+  ofstream Transaction("./testData/transactionHistory.csv");
+  Transaction << "buy,BTCUSDT,70808.2,3,1777423915" << endl;
+  Transaction.close();
+
+  promise<json> ReceivedTransaction;
+  future<json> FutureReceivedTransaction = ReceivedTransaction.get_future();
+
+  ix::WebSocket client;
+  client.setUrl("ws://127.0.0.1:9999");
+  client.setOnMessageCallback([&](const ix::WebSocketMessagePtr &msg) {
+    if (msg->type == ix::WebSocketMessageType::Message) {
+      json Received = json::parse(msg->str);
+
+      if (Received["dataType"] == "transaction") {
+        try {
+          ReceivedTransaction.set_value(Received);
+        } catch (const future_error &error) {
+        }
+      }
+    }
+  });
+
+  client.start();
+
+  ASSERT_EQ(FutureReceivedTransaction.wait_for(chrono::seconds(1)),
+            future_status::ready);
+
+  json result = FutureReceivedTransaction.get();
+
+  EXPECT_EQ(result["dataType"], "transaction");
+  EXPECT_EQ(result["type"], "buy");
+  EXPECT_EQ(result["coin"], "BTCUSDT");
+  EXPECT_EQ(result["price"], 70808.2);
+  EXPECT_EQ(result["quantity"], 3);
+  EXPECT_EQ(result["last"], true);
+
+  client.stop();
+}
+
+/* Ten_Transactions_Are_Sent
+ *
+ * Uses the Database_HandlerTest fixture. Uses the same setup and general logic
+ * from Record_10_Transactions to record 10 random transactions. We then assert
+ * that given a webSocket client and a server which calls
+ * sendTransactionHistory(), we will get the same 10 random transactions back.
+ *
+ * 1.  Generate random of types, coins, prices, quantities...
+ * 2.  Place those all in their respective vectors.
+ * 3.  Do this 10 times:
+ *     3a. Assemble a JSON from the vectors of semi-random info.
+ *     3b. Call the Database to record it.
+ *     3c. Record onto TransactionsVector.
+ * 4.  Get a promise / future for a JSON vector.
+ * 5.  Make a webSocket client.
+ *     5a. Set its url.
+ * 6.  Set the client's callback behavior
+ *     6a. If we received a message, parse it into a JSON.
+ *     6b. If that message is a transaction, push it onto the vector.
+ *         a. If it is the last transaction, set our promise to the JSON vector.
+ * 7.  Start the client.
+ * 8.  Assert the future is ready, and wait up to one second for it.
+ * 9.  Get the result from the future.
+ * 10. Expect that each member of our result matches what should have been sent.
+ * 11. Stop client, clean up pointers.
+ */
+TEST_F(Database_HandlerTest, Ten_Transactions_Are_Sent) {
+  Database_Handler *Database = new Database_Handler("./testData/");
+  mutex PushLocker;
+  json Transaction;
+  vector<json> TransactionsVector;
+
+  random_device RAND;
+  mt19937 Generator(RAND());
+
+  uniform_int_distribution<> CoinFlip(0, 1);
+  uniform_int_distribution<> CoinSelector(0, 5);
+  uniform_real_distribution<double> DoubleDist(0.0, 100000.0);
+
+  vector<string> TransactionTypes;
+  vector<string> Coins;
+  vector<double> Prices;
+  vector<double> Quantities;
+
+  auto PickACoin = [&]() {
+    switch (CoinSelector(Generator)) {
+    case 0:
+      return "BTCUSDT";
+    case 1:
+      return "ETHUSDT";
+    case 2:
+      return "ADAUSDT";
+    case 3:
+      return "XRPUSDT";
+    case 4:
+      return "DOTUSDT";
+    case 5:
+      return "UNIUSDT";
+    default:
+      return "BTCUSDT";
+    }
+  };
+
+  for (int i = 0; i < 10; i++) {
+    TransactionTypes.push_back(CoinFlip(Generator) == 0 ? "buy" : "sell");
+    Coins.push_back(PickACoin());
+    Prices.push_back(floor(DoubleDist(Generator)));
+    Quantities.push_back(floor(DoubleDist(Generator)));
+  }
+
+  for (int i = 0; i < 10; i++) {
+    Transaction["type"] = TransactionTypes[i];
+    Transaction["coin"] = Coins[i];
+    Transaction["price"] = Prices[i];
+    Transaction["quantity"] = Quantities[i];
+
+    Database->recordTransaction(&Transaction);
+    TransactionsVector.push_back(Transaction);
+  }
+
+  vector<json> ReceivedJSONs;
+  promise<vector<json>> ReceivedPromise;
+  future<vector<json>> FutureReceivedPromise = ReceivedPromise.get_future();
+
+  ix::WebSocket client;
+  client.setUrl("ws://127.0.0.1:9999");
+  client.setOnMessageCallback([&](const ix::WebSocketMessagePtr &msg) {
+    if (msg->type == ix::WebSocketMessageType::Message) {
+      json received = json::parse(msg->str);
+
+      if (received["dataType"] == "transaction") {
+        lock_guard<mutex> lock(PushLocker);
+        ReceivedJSONs.push_back(received);
+
+        if (received["last"] == true || ReceivedJSONs.size() == 10) {
+          try {
+            ReceivedPromise.set_value(ReceivedJSONs);
+          } catch (const future_error &error) {
+          }
+        }
+      }
+    }
+  });
+
+  client.start();
+
+  ASSERT_EQ(FutureReceivedPromise.wait_for(chrono::seconds(1)),
+            future_status::ready);
+  vector<json> received = FutureReceivedPromise.get();
+
+  for (int i = 0; i < received.size(); i++) {
+    EXPECT_EQ(received[i]["coin"], TransactionsVector[i]["coin"]);
+    EXPECT_EQ(received[i]["price"], TransactionsVector[i]["price"]);
+    EXPECT_EQ(received[i]["quantity"], TransactionsVector[i]["quantity"]);
+    EXPECT_EQ(received[i]["type"], TransactionsVector[i]["type"]);
+  }
+
+  client.stop();
+  delete Database;
 }

--- a/test/DatabaseHandlerTest.cpp
+++ b/test/DatabaseHandlerTest.cpp
@@ -9,6 +9,7 @@
 
 #include "Database_Handler.h"
 #include "ixwebsocket/IXConnectionState.h"
+#include "ixwebsocket/IXNetSystem.h"
 #include "ixwebsocket/IXWebSocket.h"
 #include "ixwebsocket/IXWebSocketMessage.h"
 #include "ixwebsocket/IXWebSocketMessageType.h"
@@ -51,6 +52,7 @@ protected:
    * 6. Waits for up to 1s to see if the server grabs a port.
    */
   static void SetUpTestSuite() {
+    ix::initNetSystem();
     filesystem::create_directories("./testData/");
 
     promise<bool> IsReady;
@@ -116,6 +118,7 @@ protected:
   ix::WebSocket *socket;
 
   void SetUp() override {
+    ix::initNetSystem();
     filesystem::create_directories("./testData/");
     Database = new Database_Handler("./testData/");
   }

--- a/test/DatabaseHandlerTest.cpp
+++ b/test/DatabaseHandlerTest.cpp
@@ -9,7 +9,6 @@
 
 #include "Database_Handler.h"
 #include "ixwebsocket/IXConnectionState.h"
-#include "ixwebsocket/IXNetSystem.h"
 #include "ixwebsocket/IXWebSocket.h"
 #include "ixwebsocket/IXWebSocketMessage.h"
 #include "ixwebsocket/IXWebSocketMessageType.h"
@@ -52,7 +51,6 @@ protected:
    * 6. Waits for up to 1s to see if the server grabs a port.
    */
   static void SetUpTestSuite() {
-    ix::initNetSystem();
     filesystem::create_directories("./testData/");
 
     promise<bool> IsReady;
@@ -118,7 +116,6 @@ protected:
   ix::WebSocket *socket;
 
   void SetUp() override {
-    ix::initNetSystem();
     filesystem::create_directories("./testData/");
     Database = new Database_Handler("./testData/");
   }

--- a/test/DatabaseHandlerTest.cpp
+++ b/test/DatabaseHandlerTest.cpp
@@ -63,10 +63,18 @@ protected:
            ix::WebSocket &webSocket,
            const ix::WebSocketMessagePtr &msg) -> void {
           Database_Handler db("./testData/");
+          Database_Handler Historical("../userData/");
 
           if (msg->type == ix::WebSocketMessageType::Open) {
             db.sendHoldingsData(webSocket);
             db.sendTransactionHistory(webSocket);
+
+            Historical.sendHistoricalData(webSocket, "btcusdt");
+            Historical.sendHistoricalData(webSocket, "ethusdt");
+            Historical.sendHistoricalData(webSocket, "adausdt");
+            Historical.sendHistoricalData(webSocket, "xrpusdt");
+            Historical.sendHistoricalData(webSocket, "dotusdt");
+            Historical.sendHistoricalData(webSocket, "uniusdt");
           }
         });
 
@@ -493,4 +501,90 @@ TEST_F(Database_HandlerTest, Ten_Transactions_Are_Sent) {
 
   client.stop();
   delete Database;
+}
+
+/* Sends_Historical_Data
+ *
+ * Uses the Database_HandlerTest fixture.
+ * In this test, we expect to receive historical data when given a valid
+ * webSocket client, and a server that calls sendHistoricalData(). In this case,
+ * we use the provided historical data in the userData directory.
+ *
+ * 1. Get a promise / future of JSON vectors.
+ * 2. Make a webSocket client.
+ *    2a. Set its url.
+ * 3. Set the client's callback behavior.
+ *    3a. If we get a message, parse it into a JSON.
+ *    3b. If the message's dataType is "historical", push it onto
+ *        ReceivedVector. 3c. If the last flag is set, set the ReceivedPromise
+ *        with ReceivedVector.
+ * 4. Start the client.
+ * 5. Assert the future is ready, and wait up to one second for it.
+ * 6. Get the result from the future.
+ * 7. For each received JSON:
+ *    7a. Expect any two adjacent JSONs are not equal (no duplicate histories).
+ *    7b. Expect dataType is not null, is a string, and is "historical"
+ *    7c. Expect coin is not null, is a number, and is any of "the coins"
+ *    7d. Expect time is not null, is a number, and strictly increments.
+ *    7e. Expect price is not null, is a number, and differs from its neighbors.
+ * 8. Stop the client.
+ */
+TEST_F(Database_HandlerTest, Sends_Historical_Data) {
+  mutex PushLocker;
+  vector<json> ReceivedVector;
+  promise<vector<json>> ReceivedPromise;
+  future<vector<json>> FutureReceivedPromise = ReceivedPromise.get_future();
+
+  ix::WebSocket client;
+  client.setUrl("ws://127.0.0.1:9999");
+  client.setOnMessageCallback([&](const ix::WebSocketMessagePtr &msg) {
+    if (msg->type == ix::WebSocketMessageType::Message) {
+      json received = json::parse(msg->str);
+
+      if (received["dataType"] == "historical") {
+        lock_guard<mutex> lock(PushLocker);
+        ReceivedVector.push_back(received);
+
+        if (received["last"] == true) {
+          try {
+            ReceivedPromise.set_value(ReceivedVector);
+          } catch (const future_error &error) {
+          }
+        }
+      }
+    }
+  });
+
+  client.start();
+
+  ASSERT_EQ(FutureReceivedPromise.wait_for(chrono::seconds(1)),
+            future_status::ready);
+
+  vector<json> Received = FutureReceivedPromise.get();
+
+  for (int i = 0; i < Received.size() - 1; i++) {
+    EXPECT_NE(Received[i], Received[i + 1]);
+
+    EXPECT_FALSE(Received[i]["dataType"].is_null());
+    EXPECT_TRUE(Received[i]["dataType"].is_string());
+    EXPECT_EQ(Received[i]["dataType"], "historical");
+
+    EXPECT_FALSE(Received[i]["coin"].is_null());
+    EXPECT_TRUE(Received[i]["coin"].is_string());
+    EXPECT_THAT(Received[i]["coin"],
+                testing::AnyOf(testing::Eq("btcusdt"), testing::Eq("ethusdt"),
+                               testing::Eq("adausdt"), testing::Eq("xrpusdt"),
+                               testing::Eq("dotusdt"), testing::Eq("uniusdt")));
+
+    EXPECT_FALSE(Received[i]["time"].is_null());
+    EXPECT_TRUE(Received[i]["time"].is_number());
+    EXPECT_NE(Received[i]["time"], Received[i + 1]["time"]);
+    EXPECT_TRUE(Received[i]["time"] < Received[i + 1]["time"]);
+
+    EXPECT_FALSE(Received[i]["price"].is_null());
+    EXPECT_TRUE(Received[i]["price"].is_number());
+    EXPECT_NE(Received[i]["price"], Received[i + 1]["price"]);
+  }
+
+  client.stop();
 }

--- a/test/DatabaseHandlerTest.cpp
+++ b/test/DatabaseHandlerTest.cpp
@@ -280,6 +280,7 @@ TEST_F(TestDB, Record_10_Transactions) {
  * 9. Stop the client
  */
 TEST_F(Database_HandlerTest, Holdings_Are_Sent) {
+  filesystem::remove_all("./testData/holdings.csv");
   ofstream Holding("./testData/holdings.csv");
   Holding << "BTCUSDT,1.5" << endl;
   Holding.close();
@@ -315,6 +316,7 @@ TEST_F(Database_HandlerTest, Holdings_Are_Sent) {
   EXPECT_EQ(result["last"], true);
 
   client.stop();
+  filesystem::remove_all("./testData/holdings.csv");
 }
 
 /* Transactions_Are_Sent
@@ -343,6 +345,7 @@ TEST_F(Database_HandlerTest, Holdings_Are_Sent) {
  * 9. Stop the client.
  */
 TEST_F(Database_HandlerTest, Transactions_Are_Sent) {
+  filesystem::remove_all("./testData/transactionHistory.csv");
   ofstream Transaction("./testData/transactionHistory.csv");
   Transaction << "buy,BTCUSDT,70808.2,3,1777423915" << endl;
   Transaction.close();
@@ -380,6 +383,7 @@ TEST_F(Database_HandlerTest, Transactions_Are_Sent) {
   EXPECT_EQ(result["last"], true);
 
   client.stop();
+  filesystem::remove_all("./testData/transactionHistory.csv");
 }
 
 /* Ten_Transactions_Are_Sent

--- a/test/ExchangeClientTest.cpp
+++ b/test/ExchangeClientTest.cpp
@@ -10,6 +10,7 @@
  */
 
 #include "ExchangeClient.h"
+#include "ixwebsocket/IXNetSystem.h"
 #include "ixwebsocket/IXWebSocket.h"
 #include "ixwebsocket/IXWebSocketErrorInfo.h"
 #include "ixwebsocket/IXWebSocketMessage.h"
@@ -77,6 +78,7 @@ protected:
    * 6. Waits for up to 1s to see if the server grabs a port.
    */
   static void SetUpTestSuite() {
+    ix::initNetSystem();
     promise<bool> IsReady;
     future<bool> FutureServerReady = IsReady.get_future();
 
@@ -139,6 +141,9 @@ public:
  * ExchangeClient.
  */
 class MockClientHooks {
+protected:
+  void SetUp() { ix::initNetSystem(); }
+
 public:
   MOCK_METHOD(void, OnOpen, (), ());
   MOCK_METHOD(void, OnMessage, (const string &msg), ());

--- a/test/ExchangeClientTest.cpp
+++ b/test/ExchangeClientTest.cpp
@@ -78,7 +78,6 @@ protected:
    * 6. Waits for up to 1s to see if the server grabs a port.
    */
   static void SetUpTestSuite() {
-    ix::initNetSystem();
     promise<bool> IsReady;
     future<bool> FutureServerReady = IsReady.get_future();
 
@@ -142,7 +141,7 @@ public:
  */
 class MockClientHooks {
 protected:
-  void SetUp() { ix::initNetSystem(); }
+  void SetUpTestSuite() { ix::initNetSystem(); }
 
 public:
   MOCK_METHOD(void, OnOpen, (), ());


### PR DESCRIPTION
# Description

This PR adds three tests to `DatabaseHandlerTest.cpp`, which were missing from the first PR in #96.

We have three tests as follows:

`Transactions_Are_Sent`, which asserts that a server calling `sendTransactionHistory()` will in fact send a transaction from the `transactionHistory.csv` file.

`Ten_Transactions_Are_Sent`, which asserts the same, except for a `transactionHistory.csv` file containing 10 random transactions.

`Sends_Historical_Data`, which uses the live historical data in `userData/`. We claim each entry is unique, and has all required parts.

## Test count

Total test count is up to 204 for the CPP backend and all of its dependencies:

<img width="747" height="393" alt="image" src="https://github.com/user-attachments/assets/580271f0-9837-4e28-9a0c-ec61746b02b3" />
